### PR TITLE
chore: bump Rust version to 1.95 and minor cleanups

### DIFF
--- a/.github/workflows/build-and-push-action.yml
+++ b/.github/workflows/build-and-push-action.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  GHCR_IMAGE: ghcr.io/${{ secrets.GHCR_USERNAME }}/${{ github.event.repository.name }}  
+  GHCR_IMAGE: ghcr.io/${{ secrets.GHCR_USERNAME }}/${{ github.event.repository.name }}
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /dist
 *.rs.bk
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.83 as builder
+FROM rust:1.95 as builder
 
 WORKDIR /app
 


### PR DESCRIPTION
- Bump Rust builder image from 1.83 to 1.95 in Dockerfile
- Add .idea to .gitignore
- Remove trailing whitespace in GitHub Actions build workflow