### PR TITLE
ci: update workflow runners and Rust edition

### DIFF
--- a/.github/workflows/build-and-push-action.yml
+++ b/.github/workflows/build-and-push-action.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-24.04
+            runner: ubuntu-latest
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
@@ -77,7 +77,7 @@ jobs:
 
   push:
     name: Merge Docker manifests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs:
       - build
     steps:
@@ -125,7 +125,7 @@ jobs:
           docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}        
 
   notify:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: push
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "actions-telegram-notifier"
 version = "3.0.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 serde_json = "1.0.150"


### PR DESCRIPTION
Update GitHub Actions runners from ubuntu-24.04 to ubuntu-latest and change Rust edition from 2024 to 2021 in Cargo.toml.