### PR TITLE
chore(deps): downgrade core dependencies in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "3.0.0"
 edition = "2021"
 
 [dependencies]
-serde_json = "1.0.150"
-reqwest = { version = "0.13.4", features = ["blocking", "json"] }
-tokio = { version = "1.52.3", features = ["rt", "rt-multi-thread", "macros"] }
-serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.140"
+reqwest = { version = "0.13.2", features = ["blocking", "json"] }
+tokio = { version = "1.44.0", features = ["rt", "rt-multi-thread", "macros"] }
+serde = { version = "1.0.219", features = ["derive"] }


### PR DESCRIPTION
- Downgrade serde_json from 1.0.150 to 1.0.140
- Downgrade reqwest from 0.13.4 to 0.13.2
- Downgrade tokio from 1.52.3 to 1.44.0
- Downgrade serde from 1.0.228 to 1.0.219
- Update h2 sub-dependency to 0.4.14 in Cargo.lock