### PR TITLE
build: bump rust version, dependencies, and github actions

### DIFF
--- a/.github/workflows/build-and-push-action.yml
+++ b/.github/workflows/build-and-push-action.yml
@@ -32,26 +32,26 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_IMAGE }}
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Checkout code
         uses: actions/checkout@v6
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           provenance: false # Disable provenance to avoid unknown/unknown
           sbom: false       # Disable sbom to avoid unknown/unknown
@@ -68,7 +68,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -82,21 +82,21 @@ jobs:
       - build
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -107,7 +107,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_IMAGE }}
           tags: |
@@ -130,8 +130,8 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@v6
+ 
       - name: Run Telegram Notify Action
         uses: proDreams/actions-telegram-notifier@main
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "actions-telegram-notifier"
 version = "3.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
-serde_json = "1.0.140"
-reqwest = { version = "0.13.2", features = ["blocking", "json"] }
-tokio = { version = "1.44.0", features = ["rt", "rt-multi-thread", "macros"] }
-serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.150"
+reqwest = { version = "0.13.4", features = ["blocking", "json"] }
+tokio = { version = "1.52.3", features = ["rt", "rt-multi-thread", "macros"] }
+serde = { version = "1.0.228", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.83 as builder
+FROM rust:1.95-bookworm AS builder
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN cargo build --release
 
-FROM debian:bookworm-slim as runtime
+FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update && apt-get install -y \
     libssl-dev \


### PR DESCRIPTION
- Update Rust builder image to 1.95-bookworm and bump edition to 2024
- Update Cargo dependencies (serde_json, reqwest, tokio, serde)
- Bump versions for various GitHub Actions (actions/* and docker/*) in the build workflow